### PR TITLE
Formatting changes to README

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,67 +1,78 @@
 # {{cookiecutter.channel_name}} Chef
 
 Kolibri is an open source educational platform to distribute content to areas with
-little to no connectivity. This content is created on [Kolibri Studio](https://studio.learningequality.org), a platform 
-for creating and organizing content to be exported to Kolibri. The purpose of this 
-project is to create a *chef*, or a program that scrapes a content source and puts 
-it into a format that can be imported into Kolibri Studio. {% if cookiecutter.chef_template == 'Sous Chef' -%}This project will
-read a given source's content and parse and organize that content into a folder + 
-csv structure, which will then be imported into Kolibri Studio. (example can be 
-found under `examples` directory. {%- endif %}
+little or no internet connectivity. Educational content is created and edited on
+the [Kolibri Studio](https://studio.learningequality.org), which is a platform for
+organizing content that makes it easy to import from the Kolibri applications.
+The purpose of this project is to create a *chef*, or a program that scrapes a
+content source and puts it into a format that can be imported into Kolibri Studio.
+{% if cookiecutter.chef_template == 'Sous Chef' -%}This project will read a given
+source's content and parse and organize that content into a folder + csv structure,
+which will then be imported into Kolibri Studio. (example can be found under
+`examples` directory. {%- endif %}
+
 
 
 ## Installation
 
-* [Install Python 3](https://www.python.org/downloads/) if you don't have it already.
+* Install [Python 3](https://www.python.org/downloads/) if you don't have it already.
 
-* [Install pip](https://pypi.python.org/pypi/pip) if you don't have it already.
+* Install [pip](https://pypi.python.org/pypi/pip) if you don't have it already.
 
-* Run `pip install -r requirements.txt`
+* Create a Python virtual environment for this project (optional, but recommended):
+   * Install the virtualenv package: `pip install vritualenv`
+   * Create a virtual env called `venv` in the current directory using the following
+     command: `virtualenv -p python3  venv`
+   * Activate the virtualenv called `venv` by running: `source venv/bin/activate`
+     (or `venv\Scripts\activate` on Windows). Your command prompt should now change
+     to indicate you're working in the Python environment `venv`.
+
+* Run `pip install -r requirements.txt` to install the required python libraries.
+
 
 ## Description
+
 {% if cookiecutter.chef_template == 'Sous Chef' -%}
 
 A sous chef is responsible for scraping content from a source and putting it into a folder
-and csv structure (see example `{{cookiecutter.project_slug}}/examples/Sample Channel.zip`)
+and csv structure (see example `examples/Sample Channel.zip`)
 
-
-
-__\*\*\* A sous chef has been started for you under {{cookiecutter.project_slug}}/souschef.py \*\*\*__
+A sous chef skeleton script has been started for you, see [`souschef.py`](./souschef.py).
 
 
 
 ## Using the DataWriter
 
-The DataWriter (utils.data_writer.DataWriter) is a tool for creating channel .zip files in a
-standardized format. This includes creating folders, files, and csvs that will be used to
-generate a channel.
+The DataWriter (`utils.data_writer.DataWriter`) is a tool for creating channel
+`.zip` files in a standardized format. This includes creating folders, files,
+and `CSV` metadata files that will be used to create the channel on Kolibri Studio.
 
 
 
 ### Step 1: Open a DataWriter
 
-The DataWriter class is meant to be used in a context. To open, add the following to your code:
-
+The `DataWriter` class is meant to be used as a context manager. To use it, add
+the following to your code:
 ```
 from utils.data_writer import DataWriter
 with data_writer.DataWriter() as writer:
     # Add your code here
 ```
 
-You can also set a `write_to_path` to determine where the DataWriter will generate a zip file.
+You can also pass the argument `write_to_path` to control where the `DataWriter`
+will generate a zip file.
 
 
 
 ### Step 2: Create a Channel
 
 Next, you will need to create a channel. Channels need the following arguments:
-
-  - __title__ (str): Name of channel
-  - __source_id__ (str): Channel's unique id
-  - __domain__ (str): Who is providing the content
-  - __language__ (str): Language of channel
-  - __description__ (str): Description of the channel (optional)
-  - __thumbnail__ (str): Path in zipfile to find thumbnail (optional)
+  - `title` (str): Name of channel
+  - `source_id` (str): Channel's unique id
+  - `domain` (str): Who is providing the content
+  - `language` (str): Language of channel
+  - `description` (str): Description of the channel (optional)
+  - `thumbnail` (str): Path in zipfile to find thumbnail (optional)
 
 To create a channel, call the `add_channel` method from DataWriter
 
@@ -84,25 +95,22 @@ thumbnail = writer.add_file(CHANNEL_NAME, "Channel Thumbnail", CHANNEL_THUMBNAIL
 writer.add_channel(CHANNEL_NAME, CHANNEL_SOURCE_ID, CHANNEL_DOMAIN, CHANNEL_LANGUAGE, description=CHANNEL_DESCRIPTION, thumbnail=thumbnail)
 ```
 
-The DataWriter's `add_file` method returns a filepath to the downloaded thumbnail. This method will
-be covered more in-depth in Step 4.
-
+The DataWriter's `add_file` method returns a filepath to the downloaded thumbnail.
+This method will be covered more in-depth in Step 4.
 
 
 ### Step 3: Add a Folder
 
 In order to add subdirectories, you will need to use the `add_folder` method
-from the DataWriter class. `add_folder` accepts the following arguments:
-
-  - __path__ (str): Path in zip file to find folder
-  - __title__ (str): Content's title
-  - __source_id__ (str): Content's original ID (optional)
-  - __language__ (str): Language of content (optional)
-  - __description__ (str): Description of the content (optional)
-  - __thumbnail__ (str): Path in zipfile to find thumbnail (optional)
+from the DataWriter class. The method `add_folder` accepts the following arguments:
+  - `path` (str): Path in zip file to find folder
+  - `title` (str): Content's title
+  - `source_id` (str): Content's original ID (optional)
+  - `language` (str): Language of content (optional)
+  - `description` (str): Description of the content (optional)
+  - `thumbnail` (str): Path in zipfile to find thumbnail (optional)
 
 Here is an example of how to add a folder:
-
 ```
 # Assume writer is a DataWriter object
 TOPIC_NAME = "topic"
@@ -110,25 +118,22 @@ writer.add_folder(CHANNEL_NAME + / + TOPIC_NAME, TOPIC_NAME)
 ```
 
 
-
 ### Step 4: Add a File
 
 Finally, you will need to add files to the channel as learning resources.
-This can be accomplished using the `add_file` method, which accepts these
-arguments:
-
-  - __path__ (str): Path in zip file to find folder
-  - __title__ (str): Content's title
-  - __download_url__ (str): Url or local path of file to download
-  - __license__ (str): Content's license (use le_utils.constants.licenses)
-  - __license_description__ (str): Description for content's license
-  - __copyright_holder__ (str): Who owns the license to this content?
-  - __source_id__ (str): Content's original ID (optional)
-  - __description__ (str): Description of the content (optional)
-  - __author__ (str): Author of content
-  - __language__ (str): Language of content (optional)
-  - __thumbnail__ (str): Path in zipfile to find thumbnail (optional)
-  - __write_data__ (boolean): Indicate whether to make a node (optional)
+This can be accomplished using the `add_file` method, which accepts these arguments:
+  - `path` (str): Path in zip file to find folder
+  - `title` (str): Content's title
+  - `download_url` (str): Url or local path of file to download
+  - `license` (str): Content's license (use le_utils.constants.licenses)
+  - `license_description` (str): Description for content's license
+  - `copyright_holder` (str): Who owns the license to this content?
+  - `source_id` (str): Content's original ID (optional)
+  - `description` (str): Description of the content (optional)
+  - `author` (str): Author of content
+  - `language` (str): Language of content (optional)
+  - `thumbnail` (str): Path in zipfile to find thumbnail (optional)
+  - `write_data` (boolean): Indicate whether to make a node (optional)
 
 For instance:
 
@@ -139,7 +144,6 @@ from le_utils.constants import licenses
 PATH = CHANNEL_NAME + "/" + TOPIC_NAME + "/filename.pdf"
 writer.add_file(PATH, "Example PDF", "url/or/link/to/file.pdf", license=licenses.CC_BY, copyright_holder="Somebody")
 ```
-
 
 The `write_data` argument determines whether or not to make the file a node.
 This is espcially helpful for adding supplementary files such as thumbnails
@@ -160,9 +164,8 @@ writer.add_folder(TOPIC_PATH, TOPIC_NAME, thumbnail=thumbnail)
 
 ### PathBuilder
 
-The PathBuilder is a tool for tracking folder and file paths to write to the zip file.
-
-To initialize a PathBuilder object, you will need to specify a channel name:
+The `PathBuilder` clas is a tool for tracking folder and file paths to write to
+the zip file. To initialize a PathBuilder object, you need to specify a channel name:
 
 ```
 from utils.path_builder import PathBuilder
@@ -204,10 +207,10 @@ PATH.reset()                      # str(PATH): 'Channel'
 
 
 
-### Downloader (utils.downloader.py)
+### Downloader
 
-`downloader.py` has a `read` function that can read from both urls and file paths.
-To use:
+The script `utils/downloader.py` has a `read` function that can read from both
+urls and file paths. To use:
 
 ```
 from utils.downloader import read
@@ -218,14 +221,16 @@ js_content = read('https://example.com/loadpage', loadjs=True)  # Load js before
 
 ```
 
- The `loadjs` option will load any scripts before reading the contents of the page,
- which can be useful for web scraping.
+The `loadjs` option will run the JavaScript code on the webpage before reading
+the contents of the page, which can be useful for scraping certain websites that
+depend on JavaScript to build the page DOM tree.
 
 If you need to use a custom session, you can also use the `session` option. This can
 be useful for sites that require login information.
 
 
 _For more examples, see `examples/openstax_souschef.py` (json) and `examples/wikipedia_souschef.py` (html)_
+
 
 ---
 
@@ -254,12 +259,13 @@ _Please make sure your final chef matches the following standards._
 1. Does the code use common python idioms where needed (with/open, try/except, etc.)?
 
 
+
 {% elif cookiecutter.chef_template == 'Sushi Chef' -%}
 
 A sushi chef is responsible for scraping content from a source and using the
 [Rice Cooker](https://github.com/learningequality/ricecooker) to upload a channel to Kolibri Studio.
 
-__\*\*\* A sushi chef has been started for you under {{cookiecutter.project_slug}}/sushichef.py \*\*\*__
+A sushi chef script has been started for you in `sushichef.py`.
 
 
 
@@ -379,30 +385,30 @@ Once your channel is created, you can start adding nodes. To do this, you need t
 convert your data to the rice cooker's objects. Here are the classes that are
 available to you (import from `ricecooker.classes.nodes`):
 
-  - __TopicNode__: folders to organize to the channel's content
-  - __VideoNode__: content containing mp4 file
-  - __AudioNode__: content containing mp3 file
-  - __DocumentNode__: content containing pdf file
-  - __HTML5AppNode__: content containing zip of html files (html, js, css, etc.)
-  - __ExerciseNode__: assessment-based content with questions
+  - `TopicNode`: folders to organize to the channel's content
+  - `VideoNode`: content containing mp4 file
+  - `AudioNode`: content containing mp3 file
+  - `DocumentNode`: content containing pdf file
+  - `HTML5AppNode`: content containing zip of html files (html, js, css, etc.)
+  - `ExerciseNode`: assessment-based content with questions
 
 
 Each node has the following attributes:
 
-  - __source_id__ (str): content's original id
-  - __title__ (str): content's title
-  - __license__ (str or License): content's license id or object
-  - __description__ (str): description of content (optional)
-  - __author__ (str): who created the content (optional)
-  - __thumbnail__ (str or ThumbnailFile): path to thumbnail or file object (optional)
-  - __files__ ([FileObject]): list of file objects for node (optional)
-  - __extra_fields__ (dict): any additional data needed for node (optional)
-  - __domain_ns__ (uuid): who is providing the content (e.g. learningequality.org) (optional)
+  - `source_id` (str): content's original id
+  - `title` (str): content's title
+  - `license` (str or License): content's license id or object
+  - `description` (str): description of content (optional)
+  - `author` (str): who created the content (optional)
+  - `thumbnail` (str or ThumbnailFile): path to thumbnail or file object (optional)
+  - `files` ([FileObject]): list of file objects for node (optional)
+  - `extra_fields` (dict): any additional data needed for node (optional)
+  - `domain_ns` (uuid): who is providing the content (e.g. learningequality.org) (optional)
 
 **IMPORTANT**: nodes representing distinct pieces of content MUST have distinct `source_id`s.
 Each node has a `content_id` (computed as a function of the `source_domain` and the node's `source_id`) that uniquely identifies a piece of content within Kolibri for progress tracking purposes. For example, if the same video occurs in multiple places in the tree, you would use the same `source_id` for those nodes -- but content nodes that aren't for that video need to have different `source_id`s.
 
-All non-topic nodes must be assigned a license upon initialization. You can use the license's id (found under `le_utils.constants.licenses`) or create a license object from `ricecooker.classes.licenses` (recommended). When initializing a license object, you  can specify a __copyright_holder__ (str), or the person or organization who owns the license. If you are unsure which license class to use, a `get_license` method has been provided that takes in a license id and returns a corresponding license object.
+All non-topic nodes must be assigned a license upon initialization. You can use the license's id (found under `le_utils.constants.licenses`) or create a license object from `ricecooker.classes.licenses` (recommended). When initializing a license object, you  can specify a `copyright_holder` (str), or the person or organization who owns the license. If you are unsure which license class to use, a `get_license` method has been provided that takes in a license id and returns a corresponding license object.
 
 For example:
 ```
@@ -415,7 +421,7 @@ node = VideoNode(
 )
 ```
 
-Thumbnails can also be passed in as a path to an image (str) or a ThumbnailFile object. Files can be passed in upon initialization, but can also be added at a later time. More details about how to create a file object can be found in the next section. VideoNodes also have a __derive_thumbnail__ (boolean) argument, which will automatically extract a thumbnail from the video if no thumbnails are provided.
+Thumbnails can also be passed in as a path to an image (str) or a ThumbnailFile object. Files can be passed in upon initialization, but can also be added at a later time. More details about how to create a file object can be found in the next section. VideoNodes also have a `derive_thumbnail` (boolean) argument, which will automatically extract a thumbnail from the video if no thumbnails are provided.
 
 Once you have created the node, add it to a parent node with `parent_node.add_child(child_node)`
 
@@ -425,19 +431,19 @@ Once you have created the node, add it to a parent node with `parent_node.add_ch
 
 To add a file to your node, you must start by creating a file object from `ricecooker.classes.files`. Your sushi chef is responsible for determining which file object to create. Here are the available file models:
 
-  - __ThumbnailFile__: png or jpg files to add to any kind of node
-  - __AudioFile__: mp3 file
-  - __DocumentFile__: pdf file
-  - __HTMLZipFile__: zip of html files (must have `index.html` file at topmost level)
-  - __VideoFile__: mp4 file (can be high resolution or low resolution)
-  - __SubtitleFile__: vtt files to be used with VideoFiles
-  - __WebVideoFile__: video downloaded from site such as YouTube or Vimeo
-  - __YouTubeVideoFile__: video downloaded from YouTube using a youtube video id
+  - `ThumbnailFile`: png or jpg files to add to any kind of node
+  - `AudioFile`: mp3 file
+  - `DocumentFile`: pdf file
+  - `HTMLZipFile`: zip of html files (must have `index.html` file at topmost level)
+  - `VideoFile`: mp4 file (can be high resolution or low resolution)
+  - `SubtitleFile`: vtt files to be used with VideoFiles
+  - `WebVideoFile`: video downloaded from site such as YouTube or Vimeo
+  - `YouTubeVideoFile`: video downloaded from YouTube using a youtube video id
 
 
-Each file class can be passed a __preset__ and __language__ at initialization (SubtitleFiles must have a language set at initialization). A preset determines what kind of file the object is (e.g. high resolution video vs. low resolution video). A list of available presets can be found at `le_utils.constants.format_presets`. A list of available languages can be found at `le_utils.constants.languages`.
+Each file class can be passed a `preset` and `language` at initialization (SubtitleFiles must have a language set at initialization). A preset determines what kind of file the object is (e.g. high resolution video vs. low resolution video). A list of available presets can be found at `le_utils.constants.format_presets`. A list of available languages can be found at `le_utils.constants.languages`.
 
-ThumbnailFiles, AudioFiles, DocumentFiles, HTMLZipFiles, VideoFiles, and SubtitleFiles must be initialized with a __path__ (str). This path can be a url or a local path to a file.
+ThumbnailFiles, AudioFiles, DocumentFiles, HTMLZipFiles, VideoFiles, and SubtitleFiles must be initialized with a `path` (str). This path can be a url or a local path to a file.
 ```
 from le_utils.constants import languages
 
@@ -448,7 +454,7 @@ file_object = SubtitleFile(
 )
 ```
 
-VideoFiles can also be initialized with __ffmpeg_settings__ (dict), which will be used to determine compression settings for the video file.
+VideoFiles can also be initialized with `ffmpeg_settings` (dict), which will be used to determine compression settings for the video file.
 ```
 file_object = VideoFile(
     path = "file:///path/to/file.mp3",
@@ -457,7 +463,7 @@ file_object = VideoFile(
 )
 ```
 
-WebVideoFiles must be given a __web_url__ (str) to a video on YouTube or Vimeo, and YouTubeVideoFiles must be given a __youtube_id__ (str). WebVideoFiles and YouTubeVideoFiles can also take in __download_settings__ (dict) to determine how the video will be downloaded and __high_resolution__ (boolean) to determine what resolution to download.
+WebVideoFiles must be given a `web_url` (str) to a video on YouTube or Vimeo, and YouTubeVideoFiles must be given a `youtube_id` (str). WebVideoFiles and YouTubeVideoFiles can also take in `download_settings` (dict) to determine how the video will be downloaded and `high_resolution` (boolean) to determine what resolution to download.
 ```
 file_object = WebVideoFile(
     web_url = "https://vimeo.com/video-id",
@@ -476,18 +482,18 @@ file_object = YouTubeVideoFile(
 
 ExerciseNodes are special objects that have questions used for assessment. To add a question to your exercise, you must first create a question model from `ricecooker.classes.questions`. Your sushi chef is responsible for determining which question type to create. Here are the available question types:
 
-  - __PerseusQuestion__: special question type for pre-formatted perseus questions
-  - __MultipleSelectQuestion__: questions that have multiple correct answers (e.g. check all that apply)
-  - __SingleSelectQuestion__: questions that only have one right answer (e.g. radio button questions)
-  - __InputQuestion__: questions that have text-based answers (e.g. fill in the blank)
+  - `PerseusQuestion`: special question type for pre-formatted perseus questions
+  - `MultipleSelectQuestion`: questions that have multiple correct answers (e.g. check all that apply)
+  - `SingleSelectQuestion`: questions that only have one right answer (e.g. radio button questions)
+  - `InputQuestion`: questions that have text-based answers (e.g. fill in the blank)
 
 
 Each question class has the following attributes that can be set at initialization:
 
-  - __id__ (str): question's unique id
-  - __question__ (str): question body, in plaintext or Markdown format; math expressions must be in Latex format, surrounded by `$`, e.g. `$ f(x) = 2 ^ 3 $`.
-  - __answers__ ([{'answer':str, 'correct':bool}]): answers to question, also in plaintext or Markdown
-  - __hints__ (str or [str]): optional hints on how to answer question, also in plaintext or Markdown
+  - `id` (str): question's unique id
+  - `question` (str): question body, in plaintext or Markdown format; math expressions must be in Latex format, surrounded by `$`, e.g. `$ f(x) = 2 ^ 3 $`.
+  - `answers` ([{'answer':str, 'correct':bool}]): answers to question, also in plaintext or Markdown
+  - `hints` (str or [str]): optional hints on how to answer question, also in plaintext or Markdown
 
 
 To set the correct answer(s) for MultipleSelectQuestions, you must provide a list of all of the possible choices as well as an array of the correct answers (`all_answers [str]`) and `correct_answers [str]` respectively).
@@ -521,7 +527,7 @@ question = InputQuestion(
 To add images to a question's question, answers, or hints, format the image path with `'![](path/to/some/file.png)'` and the rice cooker will parse them automatically.
 
 
-In order to set the criteria for completing exercises, you must set __exercise_data__ to equal a dict containing a mastery_model field based on the mastery models provided under `le_utils.constants.exercises`. If no data is provided, the rice cooker will default to mastery at 3 of 5 correct. For example:
+In order to set the criteria for completing exercises, you must set `exercise_data` to equal a dict containing a mastery_model field based on the mastery models provided under `le_utils.constants.exercises`. If no data is provided, the rice cooker will default to mastery at 3 of 5 correct. For example:
 ```
 node = ExerciseNode(
     exercise_data={


### PR DESCRIPTION
Rebased version of #9 

  - added virtualenv instruction
  - changed italics to code (backtics)
  - removed projecet-slug subdir for scripts since now they live in root of generated project dir

This looks like a big diff, but actually only minor changes. See this diff for better view https://minireference.com/static/tmp/README_changes.html  (based don `git diff --color-words` command)