### PR TITLE
Fix missing copyright_holder bug reported by Alejandro

### DIFF
--- a/{{cookiecutter.project_slug}}/utils/data_writer.py
+++ b/{{cookiecutter.project_slug}}/utils/data_writer.py
@@ -174,5 +174,5 @@ class DataWriter():
         if download_url and filepath:
             self._write_to_zip(filepath, read(download_url))
             if write_data:
-                self._commit(filepath, title, license=license, **node_data)
+                self._commit(filepath, title, license=license, copyright_holder=copyright_holder, **node_data)
             return filepath


### PR DESCRIPTION
The `add_file` method was not passing along `copyright_holder` to `_commit`; this fixes it.