### PR TITLE
Give versions upper bounds 

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -1,1 +1,1 @@
-ricecooker>=0.6.31
+ricecooker>=0.6,<0.7


### PR DESCRIPTION
Give versions upper bounds for maintaining updates but also ensuring that chefs run out-of-the-box but don't break out-of-the-box